### PR TITLE
Avoid generating chunks beyond 100% and some performance improvements

### DIFF
--- a/src/main/java/supercoder79/chunkpregen/ChunkPregen.java
+++ b/src/main/java/supercoder79/chunkpregen/ChunkPregen.java
@@ -1,8 +1,14 @@
 package supercoder79.chunkpregen;
 
 import net.fabricmc.api.ModInitializer;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.util.math.ChunkSectionPos;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.poi.PointOfInterestSet;
+import net.minecraft.world.poi.PointOfInterestStorage;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import supercoder79.chunkpregen.mixin.SerializingRegionBasedStorageAccessor;
 
 public final class ChunkPregen implements ModInitializer {
 	public static final Logger LOGGER = LogManager.getLogger(ChunkPregen.class);
@@ -10,5 +16,23 @@ public final class ChunkPregen implements ModInitializer {
 	@Override
 	public void onInitialize() {
 		Commands.init();
+	}
+
+	/**
+	 * The goal here is to fix the POI memory leak that happens due to
+	 * {@link net.minecraft.world.storage.SerializingRegionBasedStorage#loadedElements} field never
+	 * actually removing POIs long after they become irrelevant. We do it here in chunk unloading
+	 * so that chunk that are fully unloaded now gets the POI removed from the POI cached storage map.
+	 */
+	public static void onChunkUnload(PointOfInterestStorage pointOfInterestStorage, Chunk chunk) {
+		ChunkPos chunkPos = chunk.getPos();
+		pointOfInterestStorage.saveChunk(chunkPos); // Make sure all POI in chunk are saved to disk first.
+
+		// Remove the cached POIs for this chunk's location.
+		int SectionPosMinY = ChunkSectionPos.getSectionCoord(chunk.getBottomY());
+		for (int currentSectionY = 0; currentSectionY < chunk.countVerticalSections(); currentSectionY++) {
+			long sectionPosKey = ChunkSectionPos.asLong(chunkPos.x, SectionPosMinY + currentSectionY, chunkPos.z);
+			((SerializingRegionBasedStorageAccessor<PointOfInterestSet>)pointOfInterestStorage).getLoadedElements().remove(sectionPosKey);
+		}
 	}
 }

--- a/src/main/java/supercoder79/chunkpregen/Commands.java
+++ b/src/main/java/supercoder79/chunkpregen/Commands.java
@@ -94,7 +94,7 @@ public final class Commands {
 				if (activeTask != null) {
 					activeTask.stop();
 
-					int count = activeTask.getOkCount() + activeTask.getErrorCount();
+					int count = activeTask.getOkCount() + activeTask.getErrorCount() + activeTask.getSkippedCount();
 					int total = activeTask.getTotalCount();
 
 					double percent = (double) count / total * 100.0;
@@ -111,7 +111,7 @@ public final class Commands {
 			lab.then(CommandManager.literal("status")
 					.executes(cmd -> {
 				if (activeTask != null) {
-					int count = activeTask.getOkCount() + activeTask.getErrorCount();
+					int count = activeTask.getOkCount() + activeTask.getErrorCount() + activeTask.getSkippedCount();
 					int total = activeTask.getTotalCount();
 
 					double percent = (double) count / total * 100.0;
@@ -143,8 +143,8 @@ public final class Commands {
 	private static PregenerationTask.Listener createPregenListener(ServerCommandSource source) {
 		return new PregenerationTask.Listener() {
 			@Override
-			public void update(int ok, int error, int total) {
-				pregenBar.update(ok, error, total);
+			public void update(int ok, int error, int skipped, int total) {
+				pregenBar.update(ok, error, skipped, total);
 			}
 
 			@Override

--- a/src/main/java/supercoder79/chunkpregen/PregenBar.java
+++ b/src/main/java/supercoder79/chunkpregen/PregenBar.java
@@ -21,8 +21,8 @@ public final class PregenBar implements AutoCloseable {
         this.bar.setDarkenSky(false);
     }
 
-    public void update(int ok, int error, int total) {
-        int count = ok + error;
+    public void update(int ok, int error, int skipped, int total) {
+        int count = ok + error + skipped;
 
         float percent = (float) count / total;
 

--- a/src/main/java/supercoder79/chunkpregen/PregenerationTask.java
+++ b/src/main/java/supercoder79/chunkpregen/PregenerationTask.java
@@ -13,6 +13,7 @@ import net.minecraft.server.world.ChunkTicketType;
 import net.minecraft.server.world.ServerChunkManager;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.server.world.ThreadedAnvilChunkStorage;
+import net.minecraft.util.Util;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.ChunkStatus;
@@ -87,7 +88,7 @@ public final class PregenerationTask {
         this.listener = listener;
 
         // Off thread chunk scanning to skip already generated chunks
-        CompletableFuture.runAsync(this::tryEnqueueTasks);
+        CompletableFuture.runAsync(this::tryEnqueueTasks, Util.getMainWorkerExecutor());
     }
 
     public void stop() {

--- a/src/main/java/supercoder79/chunkpregen/PregenerationTask.java
+++ b/src/main/java/supercoder79/chunkpregen/PregenerationTask.java
@@ -86,7 +86,16 @@ public final class PregenerationTask {
                 return;
             }
 
-            int enqueueCount = BATCH_SIZE - this.queuedCount.get();
+            int queuedCount = this.queuedCount.get();
+            int completedCount = this.okCount.get() + this.errorCount.get();
+            if (completedCount == this.totalCount && queuedCount == 0) {
+                this.listener.complete(this.errorCount.get());
+                this.stopped = true;
+                return;
+            }
+
+            int remainingCount = this.totalCount - (completedCount + queuedCount);
+            int enqueueCount = Math.min(BATCH_SIZE - queuedCount, remainingCount);
             if (enqueueCount <= 0) {
                 return;
             }

--- a/src/main/java/supercoder79/chunkpregen/PregenerationTask.java
+++ b/src/main/java/supercoder79/chunkpregen/PregenerationTask.java
@@ -176,16 +176,14 @@ public final class PregenerationTask {
         Iterator<ChunkPos> iterator = this.iterator;
         for (int i = 0; i < count && iterator.hasNext();) {
             ChunkPos chunkPosInLocalSpace = iterator.next();
-            if (Math.abs(chunkPosInLocalSpace.x) <= this.radius && Math.abs(chunkPosInLocalSpace.z) <= this.radius) {
-                if (isChunkFullyGenerated(chunkPosInLocalSpace)) {
-                    this.skippedCount.incrementAndGet();
-                    this.listener.update(this.okCount.get(), this.errorCount.get(), this.skippedCount.get(), this.totalCount);
-                    continue;
-                }
-
-                chunks.add(ChunkPos.toLong(chunkPosInLocalSpace.x + this.x, chunkPosInLocalSpace.z + this.z));
-                i++;
+            if (isChunkFullyGenerated(chunkPosInLocalSpace)) {
+                this.skippedCount.incrementAndGet();
+                this.listener.update(this.okCount.get(), this.errorCount.get(), this.skippedCount.get(), this.totalCount);
+                continue;
             }
+
+            chunks.add(ChunkPos.toLong(chunkPosInLocalSpace.x + this.x, chunkPosInLocalSpace.z + this.z));
+            i++;
         }
 
         return chunks;

--- a/src/main/java/supercoder79/chunkpregen/PregenerationTask.java
+++ b/src/main/java/supercoder79/chunkpregen/PregenerationTask.java
@@ -163,10 +163,11 @@ public final class PregenerationTask {
         LongList chunks = new LongArrayList(count);
 
         Iterator<ChunkPos> iterator = this.iterator;
-        for (int i = 0; i < count && iterator.hasNext(); i++) {
+        for (int i = 0; i < count && iterator.hasNext();) {
             ChunkPos chunk = iterator.next();
             if (Math.abs(chunk.x) <= this.radius && Math.abs(chunk.z) <= this.radius) {
                 chunks.add(ChunkPos.toLong(chunk.x + this.x, chunk.z + this.z));
+                i++;
             }
         }
 

--- a/src/main/java/supercoder79/chunkpregen/PregenerationTask.java
+++ b/src/main/java/supercoder79/chunkpregen/PregenerationTask.java
@@ -28,6 +28,7 @@ public final class PregenerationTask {
     private final Iterator<ChunkPos> iterator;
     private final int x;
     private final int z;
+    private final int radius;
 
     private final int totalCount;
 
@@ -47,6 +48,7 @@ public final class PregenerationTask {
         this.iterator = new CoarseOnionIterator(radius, COARSE_CELL_SIZE);
         this.x = x;
         this.z = z;
+        this.radius = radius;
 
         int diameter = radius * 2 + 1;
         this.totalCount = diameter * diameter;
@@ -86,16 +88,7 @@ public final class PregenerationTask {
                 return;
             }
 
-            int queuedCount = this.queuedCount.get();
-            int completedCount = this.okCount.get() + this.errorCount.get();
-            if (completedCount == this.totalCount && queuedCount == 0) {
-                this.listener.complete(this.errorCount.get());
-                this.stopped = true;
-                return;
-            }
-
-            int remainingCount = this.totalCount - (completedCount + queuedCount);
-            int enqueueCount = Math.min(BATCH_SIZE - queuedCount, remainingCount);
+            int enqueueCount = BATCH_SIZE - this.queuedCount.get();
             if (enqueueCount <= 0) {
                 return;
             }
@@ -169,7 +162,9 @@ public final class PregenerationTask {
         Iterator<ChunkPos> iterator = this.iterator;
         for (int i = 0; i < count && iterator.hasNext(); i++) {
             ChunkPos chunk = iterator.next();
-            chunks.add(ChunkPos.toLong(chunk.x + this.x, chunk.z + this.z));
+            if (Math.abs(chunk.x) <= this.radius && Math.abs(chunk.z) <= this.radius) {
+                chunks.add(ChunkPos.toLong(chunk.x + this.x, chunk.z + this.z));
+            }
         }
 
         return chunks;

--- a/src/main/java/supercoder79/chunkpregen/PregenerationTask.java
+++ b/src/main/java/supercoder79/chunkpregen/PregenerationTask.java
@@ -14,6 +14,7 @@ import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.ChunkStatus;
 import supercoder79.chunkpregen.iterator.CoarseOnionIterator;
 
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -40,6 +41,8 @@ public final class PregenerationTask {
 
     private volatile Listener listener;
     private volatile boolean stopped;
+
+    public static final ChunkTicketType<ChunkPos> FABRIC_PREGEN_FORCED = ChunkTicketType.create("fabric_pregen_forced", Comparator.comparingLong(ChunkPos::toLong));
 
     public PregenerationTask(ServerWorld world, int x, int z, int radius) {
         this.server = world.getServer();
@@ -172,12 +175,12 @@ public final class PregenerationTask {
 
     private void acquireChunk(long chunk) {
         ChunkPos pos = new ChunkPos(chunk);
-        this.chunkManager.addTicket(ChunkTicketType.FORCED, pos, 0, pos);
+        this.chunkManager.addTicket(FABRIC_PREGEN_FORCED, pos, 0, pos);
     }
 
     private void releaseChunk(long chunk) {
         ChunkPos pos = new ChunkPos(chunk);
-        this.chunkManager.removeTicket(ChunkTicketType.FORCED, pos, 0, pos);
+        this.chunkManager.removeTicket(FABRIC_PREGEN_FORCED, pos, 0, pos);
     }
 
     public interface Listener {

--- a/src/main/java/supercoder79/chunkpregen/iterator/CoarseOnionIterator.java
+++ b/src/main/java/supercoder79/chunkpregen/iterator/CoarseOnionIterator.java
@@ -68,7 +68,7 @@ public final class CoarseOnionIterator extends AbstractIterator<ChunkPos> {
 
         @Override
         public boolean hasNext() {
-            return this.z <= this.z1;
+            return this.x <= this.x1 && this.z <= this.z1;
         }
 
         @Override

--- a/src/main/java/supercoder79/chunkpregen/mixin/SerializingRegionBasedStorageAccessor.java
+++ b/src/main/java/supercoder79/chunkpregen/mixin/SerializingRegionBasedStorageAccessor.java
@@ -1,0 +1,14 @@
+package supercoder79.chunkpregen.mixin;
+
+import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
+import net.minecraft.world.storage.SerializingRegionBasedStorage;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.Optional;
+
+@Mixin(SerializingRegionBasedStorage.class)
+public interface SerializingRegionBasedStorageAccessor<R> {
+    @Accessor
+    Long2ObjectMap<Optional<R>> getLoadedElements();
+}

--- a/src/main/java/supercoder79/chunkpregen/mixin/ThreadedAnvilChunkStorageAccessor.java
+++ b/src/main/java/supercoder79/chunkpregen/mixin/ThreadedAnvilChunkStorageAccessor.java
@@ -1,0 +1,13 @@
+package supercoder79.chunkpregen.mixin;
+
+import net.minecraft.server.world.ChunkTaskPrioritySystem;
+import net.minecraft.server.world.ThreadedAnvilChunkStorage;
+import net.minecraft.util.thread.MessageListener;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(ThreadedAnvilChunkStorage.class)
+public interface ThreadedAnvilChunkStorageAccessor {
+    @Accessor
+    MessageListener<ChunkTaskPrioritySystem.Task<Runnable>> getMainExecutor();
+}

--- a/src/main/java/supercoder79/chunkpregen/mixin/ThreadedAnvilChunkStorageMixin.java
+++ b/src/main/java/supercoder79/chunkpregen/mixin/ThreadedAnvilChunkStorageMixin.java
@@ -1,0 +1,40 @@
+package supercoder79.chunkpregen.mixin;
+
+import it.unimi.dsi.fastutil.longs.Long2ByteMap;
+import it.unimi.dsi.fastutil.longs.Long2ByteOpenHashMap;
+import net.minecraft.server.world.ChunkHolder;
+import net.minecraft.server.world.ChunkTaskPrioritySystem;
+import net.minecraft.server.world.ThreadedAnvilChunkStorage;
+import net.minecraft.util.thread.MessageListener;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.poi.PointOfInterestStorage;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.gen.Accessor;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import supercoder79.chunkpregen.ChunkPregen;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+@Mixin(ThreadedAnvilChunkStorage.class)
+public class ThreadedAnvilChunkStorageMixin {
+
+    @Final
+    @Shadow
+    private Long2ByteMap chunkToType;
+
+    @Final
+    @Shadow
+    private PointOfInterestStorage pointOfInterestStorage;
+
+    @Inject(method = "method_18843(Lnet/minecraft/server/world/ChunkHolder;Ljava/util/concurrent/CompletableFuture;JLnet/minecraft/world/chunk/Chunk;)V",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ThreadedAnvilChunkStorage;save(Lnet/minecraft/world/chunk/Chunk;)Z"))
+    private void fabricChunkPregenerator$unloadChunkPOI(ChunkHolder chunkHolder, CompletableFuture<Chunk> completableFuture, long chunkLong, Chunk chunk, CallbackInfo ci) {
+        this.chunkToType.remove(chunkLong);
+        ChunkPregen.onChunkUnload(pointOfInterestStorage, chunk);
+    }
+}

--- a/src/main/resources/chunkpregen.mixins.json
+++ b/src/main/resources/chunkpregen.mixins.json
@@ -3,6 +3,9 @@
   "package": "supercoder79.chunkpregen.mixin",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
+    "SerializingRegionBasedStorageAccessor",
+    "ThreadedAnvilChunkStorageAccessor",
+    "ThreadedAnvilChunkStorageMixin"
   ],
   "client": [
   ],


### PR DESCRIPTION
The batch enqueueing was queueing up chunks but not checking how many to queue up before it would hit 100%. As a result, users can see at times when the progress bar shows over 100% due to lingering extra chunks that were queued up.

The fix here it a bit checking heavy. Might be a way to simplify it. But it does solve the issue at hand!

Current pregenerator code that can go beyond 100%:

https://github.com/jaskarth/fabric-chunkpregenerator/assets/40846040/503e637c-037d-4dda-a4e4-3cf296d90730


With the fix implemented:

https://github.com/jaskarth/fabric-chunkpregenerator/assets/40846040/d91576bd-2f56-4524-b95f-be6337f4f972
